### PR TITLE
K8s v1.26 지원 추가 / 부트스트랩 토큰 유효 시간 24시간으로 증가

### DIFF
--- a/controllers/infrastructure/bootstrapkubeconfig_controller.go
+++ b/controllers/infrastructure/bootstrapkubeconfig_controller.go
@@ -28,7 +28,7 @@ type BootstrapKubeconfigReconciler struct {
 
 const (
 	// ttl is the time to live for the generated bootstrap token
-	ttl = time.Minute * 30
+	ttl = time.Hour * 24
 )
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=bootstrapkubeconfigs,verbs=get;list;watch;create;update;patch;delete

--- a/installer/internal/algo/rocky8k8s.go
+++ b/installer/internal/algo/rocky8k8s.go
@@ -40,11 +40,11 @@ func NewRocky8Installer(ctx context.Context, arch, bundleAddrs string) (*Rocky8I
 		return tpl.String(), nil
 	}
 
-	install, err := parseFn(DoRocky8K8s1_22)
+	install, err := parseFn(DoRocky8K8s1_2x)
 	if err != nil {
 		return nil, err
 	}
-	uninstall, err := parseFn(UndoRocky8K8s1_22)
+	uninstall, err := parseFn(UndoRocky8K8s1_2x)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (s *Rocky8Installer) Uninstall() string {
 
 // contains the installation and uninstallation steps for the supported os and k8s
 var (
-	DoRocky8K8s1_22 = `
+	DoRocky8K8s1_2x = `
 set -euox pipefail
 
 BUNDLE_DOWNLOAD_PATH={{.BundleDownloadPath}}
@@ -137,7 +137,7 @@ sudo systemctl daemon-reload && systemctl enable kubelet && systemctl start kube
 ## starting containerd service
 sudo systemctl daemon-reload && systemctl enable containerd && systemctl start containerd`
 
-	UndoRocky8K8s1_22 = `
+	UndoRocky8K8s1_2x = `
 set -euox pipefail
 
 BUNDLE_DOWNLOAD_PATH={{.BundleDownloadPath}}
@@ -150,7 +150,7 @@ sudo systemctl stop containerd && systemctl disable containerd && systemctl daem
 ## removing containerd configurations and cni plugins
 sudo rm -rf /opt/cni/ && sudo rm -rf /opt/containerd/ &&  tar tf "$BUNDLE_PATH/containerd.tar" | xargs -n 1 echo '/' | sed 's/ //g'  | grep -e '[^/]$' | xargs rm -f
 
-## removing deb packages
+## removing rpm packages
 for pkg in kubeadm kubelet kubectl kubernetes-cni cri-tools; do
 	sudo yum remove $pkg -y
 done

--- a/installer/registry.go
+++ b/installer/registry.go
@@ -138,23 +138,20 @@ func GetSupportedRegistry() registry {
 	}
 
 	{
-		// Rocky
+		// Rocky 8
 
 		// BYOH Bundle Repository. Associate bundle with installer
-		linuxDistro := "Rocky_Linux_8.7_x86-64"
-		reg.AddBundleInstaller(linuxDistro, "v1.23.*")
-		reg.AddBundleInstaller(linuxDistro, "v1.24.*")
+		linuxDistro := "Rocky_Linux_8_x86-64"
 		reg.AddBundleInstaller(linuxDistro, "v1.25.*")
+		reg.AddBundleInstaller(linuxDistro, "v1.26.*")
 
 		/*
 		 * PLACEHOLDER - ADD MORE K8S VERSIONS HERE
 		 */
 
 		// Match any patch version of the specified Major & Minor K8s version
-		reg.AddK8sFilter("v1.22.*")
-		reg.AddK8sFilter("v1.23.*")
-		reg.AddK8sFilter("v1.24.*")
 		reg.AddK8sFilter("v1.25.*")
+		reg.AddK8sFilter("v1.26.*")
 
 		// Match concrete os version to repository os version
 		reg.AddOsFilter("Rocky_Linux_8.*_x86-64", linuxDistro)


### PR DESCRIPTION
- Rocky 리눅스 대상 K8S v1.26.x 버전 지원 추가
- 부트스트랩 토큰 유효 시간을 30분에서 24시간으로 증가